### PR TITLE
Replace "XCode" with "Xcode" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ extension that provides inline coding suggestions as you type.
 
 ## Beta Preview Policy
 
-Use of the GitHub Copilot XCode Extension is subject to [GitHub's Pre-Release Terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms). We want to remind you that:
+Use of the GitHub Copilot Xcode Extension is subject to [GitHub's Pre-Release Terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms). We want to remind you that:
 
 > Beta Previews may not be supported or may change at any time. You may receive confidential information through those programs that must remain confidential while the program is private. We'd love your feedback to make our Beta Previews better.
 


### PR DESCRIPTION
This fixes the capitalization of "Xcode" in the README.