### PR TITLE
Replace GCD with Swift Concurrency

### DIFF
--- a/ExtensionService/AuthStatusChecker.swift
+++ b/ExtensionService/AuthStatusChecker.swift
@@ -15,11 +15,11 @@ class AuthStatusChecker {
         Task {
             do {
                 let status = try await self.getCurrentAuthStatus()
-                DispatchQueue.main.async {
+                await MainActor.run {
                     notify(status.description, status == .ok)
                 }
             } catch {
-                DispatchQueue.main.async {
+                await MainActor.run {
                     notify("\(error)", false)
                 }
             }


### PR DESCRIPTION
Hi guys! It's recommended by apple not to mix GCD with Swift concurrency, and they've got like a million reasons for that