### PR TITLE
Add support for custom root certificate in GitHub Copilot for Xcode

### DIFF
--- a/Core/Sources/HostApp/AdvancedSettings/EnterpriseSection.swift
+++ b/Core/Sources/HostApp/AdvancedSettings/EnterpriseSection.swift
@@ -4,6 +4,7 @@ import Toast
 
 struct EnterpriseSection: View {
     @AppStorage(\.gitHubCopilotEnterpriseURI) var gitHubCopilotEnterpriseURI
+    @AppStorage(\.nodeExtraCaCerts) var nodeExtraCaCerts
     @Environment(\.toast) var toast
 
     var body: some View {
@@ -11,15 +12,27 @@ struct EnterpriseSection: View {
             SettingsTextField(
                 title: "Auth provider URL",
                 prompt: "https://your-enterprise.ghe.com",
-                text: DebouncedBinding($gitHubCopilotEnterpriseURI, handler: urlChanged).binding
+                text: DebouncedBinding($gitHubCopilotEnterpriseURI, handler: enterpriseUrlChanged).binding
+            )
+            SettingsTextField(
+                title: "Node extra CA certs",
+                prompt: "Path to extra CA certs (requires restart)",
+                text: DebouncedBinding($nodeExtraCaCerts, handler: nodeExtraCaCertsChanged).binding
             )
         }
     }
 
-    func urlChanged(_ url: String) {
+    func enterpriseUrlChanged(_ url: String) {
         if !url.isEmpty {
             validateAuthURL(url)
         }
+        NotificationCenter.default.post(
+            name: .gitHubCopilotShouldRefreshEditorInformation,
+            object: nil
+        )
+    }
+
+    func nodeExtraCaCertsChanged(_ path: String) {
         NotificationCenter.default.post(
             name: .gitHubCopilotShouldRefreshEditorInformation,
             object: nil

--- a/Tool/Sources/Preferences/Keys.swift
+++ b/Tool/Sources/Preferences/Keys.swift
@@ -551,6 +551,10 @@ public extension UserDefaultPreferenceKeys {
         .init(defaultValue: "", key: "GitHubCopilotEnterpriseURI")
     }
 
+    var nodeExtraCaCerts: PreferenceKey<String> {
+        .init(defaultValue: "", key: "NodeExtraCaCerts")
+    }
+
     var verboseLoggingEnabled: PreferenceKey<Bool> {
         .init(defaultValue: false, key: "VerboseLoggingEnabled")
     }


### PR DESCRIPTION
Fixes #95

Add support for specifying extra CA certificates in GitHub Copilot for Xcode.

* Add a new `@AppStorage` property for `nodeExtraCaCerts` in `Core/Sources/HostApp/AdvancedSettings/EnterpriseSection.swift`.
* Add a new `SettingsTextField` for "Node extra CA certs" in `Core/Sources/HostApp/AdvancedSettings/EnterpriseSection.swift`.
* Add a new function `nodeExtraCaCertsChanged` to handle changes in `Core/Sources/HostApp/AdvancedSettings/EnterpriseSection.swift`.
* Add a new environment variable `NODE_EXTRA_CA_CERTS` in `Tool/Sources/GitHubCopilotService/LanguageServer/GitHubCopilotService.swift`.
* Update the `environment` dictionary to include `nodeExtraCaCerts` in `Tool/Sources/GitHubCopilotService/LanguageServer/GitHubCopilotService.swift`.
* Add a new preference key `nodeExtraCaCerts` in `Tool/Sources/Preferences/Keys.swift`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/github/CopilotForXcode/pull/111?shareId=3092a9c9-9b78-45bd-b7a2-2969b2efd2ca).