### PR TITLE
Migrate pull request automation away from pull_request_target

### DIFF
--- a/.github/workflows/auto-close-pr-writer.yml
+++ b/.github/workflows/auto-close-pr-writer.yml
@@ -6,7 +6,6 @@ on:
     types: [completed]
 
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/auto-close-pr-writer.yml
+++ b/.github/workflows/auto-close-pr-writer.yml
@@ -1,0 +1,58 @@
+name: Auto-close PR writer
+
+on:
+  workflow_run:
+    workflows: [Auto-close PR]
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  close:
+    name: Run
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          COMMENT_BODY: |
+            At the moment we are not accepting contributions to the repository.
+            
+            Feedback for GitHub Copilot for Xcode can be given in the [Copilot community discussions](https://github.com/github/CopilotForXcode/discussions).
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_NUMBER:-}" ] || [ "$PR_NUMBER" = "null" ]; then
+            PR_NUMBER="$(gh api --method GET "repos/$GH_REPO/pulls" -f state=open -f head="$HEAD_OWNER:$HEAD_BRANCH" --jq 'if length == 1 then .[0].number else empty end')"
+          fi
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "Unable to identify a single open PR for workflow run; skipping."
+            exit 0
+          fi
+
+          pr_state="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq .state)"
+          if [ "$pr_state" != "open" ]; then
+            echo "PR #$PR_NUMBER is $pr_state; skipping."
+            exit 0
+          fi
+
+          head_repo="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq '.head.repo.full_name // ""')"
+          head_ref="$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER" --jq .head.ref)"
+          if [ "$head_repo" = "$GH_REPO" ] && [[ "$head_ref" == release/* ]]; then
+            echo "PR #$PR_NUMBER is from allowed release branch $head_ref in $head_repo; skipping."
+            exit 0
+          fi
+
+          gh api -X POST "repos/$GH_REPO/issues/$PR_NUMBER/comments" -f body="$COMMENT_BODY"
+          gh api -X PATCH "repos/$GH_REPO/pulls/$PR_NUMBER" -f state=closed

--- a/.github/workflows/auto-close-pr.yml
+++ b/.github/workflows/auto-close-pr.yml
@@ -1,21 +1,14 @@
 name: Auto-close PR
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened]
 
-jobs:
-  close:
-    name: Run
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - run: |
-          gh pr close ${{ github.event.pull_request.number }} --comment \
-          "At the moment we are not accepting contributions to the repository.
+permissions:
+  pull-requests: read
 
-          Feedback for GitHub Copilot for Xcode can be given in the [Copilot community discussions](https://github.com/github/CopilotForXcode/discussions)."
-        if: ${{ !(startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository) }}
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  signal:
+    name: Signal
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Auto-close signal for PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

This draft updates the pull request automation in this repository to avoid using `pull_request_target` for PR-driven workflow execution.

The replacement pattern keeps untrusted PR input in lower-privilege `pull_request` workflows and moves any required repository-write actions into a separate, narrowly scoped follow-up path. Where a follow-up workflow is needed, it re-checks the pull request context before taking action so the workflow operates on the intended PR/head commit rather than trusting mutable PR state.

## Expected workflow shift

- PR-triggered jobs run with reduced permissions.
- Repository write actions, when still needed, happen after the PR workflow completes.
- Follow-up jobs validate PR metadata before posting labels, comments, statuses, or other write-side effects.
- Workflow behavior should remain equivalent for maintainers and contributors, with the permission boundary made more explicit.

## Notes

Opening as a draft for repository-owner review before this is marked ready. Please review the workflow-specific behavior and any repository settings assumptions before merge.
